### PR TITLE
Add initial spec tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    "xinetd": "#{source_dir}"

--- a/.gemfile
+++ b/.gemfile
@@ -1,0 +1,5 @@
+source :rubygems
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 2.7']
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 0.1.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,2 @@
-require 'rake'
-require 'puppet-lint/tasks/puppet-lint'
+require 'rubygems'
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/spec/classes/xinetd_init_spec.rb
+++ b/spec/classes/xinetd_init_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'xinetd' do
+  it {
+    should contain_package('xinetd')
+    should contain_file('/etc/xinetd.conf')
+    should contain_service('xinetd').with_restart('/etc/init.d/xinetd reload')
+  }
+end

--- a/spec/defines/xinetd_service_spec.rb
+++ b/spec/defines/xinetd_service_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'xinetd::service' do
+  let :default_params do
+    {
+      'port'   => '80',
+      'server' => 'httpd'
+    }
+  end
+
+  let :title do
+    "httpd"
+  end
+
+  describe 'with default ensure' do
+    let :params do
+      default_params
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').with_ensure('present')
+    }
+  end
+
+  describe 'with ensure=present' do
+    let :params do
+      default_params.merge({'ensure' => 'present'})
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').with_ensure('present')
+    }
+  end
+
+  describe 'with ensure=absent' do
+    let :params do
+      default_params.merge({'ensure' => 'absent'})
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').with_ensure('absent')
+    }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,1 @@
-require 'pathname'
-dir = Pathname.new(__FILE__).parent
-$LOAD_PATH.unshift(dir, dir + 'lib', dir + '../lib')
-
-require 'mocha'
-require 'puppet'
-gem 'rspec', '=1.2.9'
-require 'spec/autorun'
-
-Spec::Runner.configure do |config|
-    config.mock_with :mocha
-end
-
-# We need this because the RAL uses 'should' as a method.  This
-# allows us the same behaviour but with a different method name.
-class Object
-    alias :must :should
-end
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
The coverage of xinetd::service is atrocious since most of the logic there is inside the template, but it's enough to let us run the module on jenkins.
