### PR TITLE
Include the xinetd class from xinetd::service type.

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -66,6 +66,8 @@ define xinetd::service (
   $service_type   = undef
 ) {
 
+  include xinetd
+
   if $wait {
     $mywait = $wait
   } else {
@@ -79,5 +81,6 @@ define xinetd::service (
     ensure  => $ensure,
     content => template('xinetd/service.erb'),
     notify  => Service['xinetd'],
+    require => Package['xinetd'],
   }
 }


### PR DESCRIPTION
The /etc/xinetd.d/ directory is created by the xinetd package, so the xinetd service file depends on the xinetd package.
