### PR TITLE
Add hasstatus => false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,10 +18,11 @@ class xinetd {
   }
 
   service { 'xinetd':
-    ensure  => running,
-    enable  => true,
-    restart => '/etc/init.d/xinetd reload',
-    require => [ Package['xinetd'],
-                File['/etc/xinetd.conf'] ],
+    ensure    => running,
+    enable    => true,
+    restart   => '/etc/init.d/xinetd reload',
+    require   => [ Package['xinetd'],
+                  File['/etc/xinetd.conf'] ],
+    hasstatus => false,
   }
 }


### PR DESCRIPTION
At least in Debian the xinetd script has no status command, this should work for other distros as well through process matching.
