### PR TITLE
/etc/init.d/xinetd no longer exists on Fedora

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@
 #     server_args => '--daemon --config /etc/rsync.conf',
 #  }
 #
-class xinetd {
+class xinetd inherits xinetd::params  {
 
   package { 'xinetd': }
 
@@ -20,7 +20,7 @@ class xinetd {
   service { 'xinetd':
     ensure  => running,
     enable  => true,
-    restart => '/etc/init.d/xinetd reload',
+    restart => $::xinetd::params::xinetd_restart_command,
     require => [ Package['xinetd'],
                 File['/etc/xinetd.conf'] ],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,8 @@
+# these parameters should be considered to be constant
+class xinetd::params {
+  if($::operatingsystem == 'Fedora' and $::operatingsystemrelease >= 16){
+     $xinetd_restart_command = '/usr/bin/systemctl restart xinetd.service'
+  } else {
+     $xinetd_restart_command = '/etc/init.d/xinetd reload'
+  }
+}


### PR DESCRIPTION
err: /Stage[main]/Xinetd/Service[xinetd]: Failed to call refresh: Could not restart Service[xinetd]: Execution of '/etc/init.d/xinetd reload' returned 1:  at /usr/lib/python2.7/site-packages/packstack/puppet/modules/xinetd/../xinetd/manifests/init.pp:26

systemd should be used instead
