### PR TITLE
Update restart and status checking

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,10 +10,14 @@
 #  }
 #
 class xinetd (
-  $confdir       = $xinetd::params::confdir,
-  $conffile      = $xinetd::params::conffile,
-  $package_name  = $xinetd::params::package_name,
-  $service_name  = $xinetd::params::service_name
+  $confdir            = $xinetd::params::confdir,
+  $conffile           = $xinetd::params::conffile,
+  $package_name       = $xinetd::params::package_name,
+  $service_name       = $xinetd::params::service_name,
+  $service_restart    = $xinetd::params::service_restart,
+  $service_status     = $xinetd::params::service_status,
+  $service_hasrestart = $xinetd::params::service_hasrestart,
+  $service_hasstatus  = $xinetd::params::service_hasstatus,
 ) inherits xinetd::params {
 
   File {
@@ -44,9 +48,10 @@ class xinetd (
   service { $service_name:
     ensure     => running,
     enable     => true,
-    hasrestart => false,
-    hasstatus  => true,
+    hasrestart => $service_hasrestart,
+    hasstatus  => $service_hasstatus,
+    restart    => $service_restart,
+    status     => $service_status,
     require    => File[$conffile],
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,28 +2,39 @@ class xinetd::params {
 
   case $::osfamily {
     'Debian':  {
-      $confdir       = '/etc/xinetd.d'
-      $conffile      = '/etc/xinetd.conf'
-      $package_name  = 'xinetd'
-      $service_name  = 'xinetd'
+      $confdir            = '/etc/xinetd.d'
+      $conffile           = '/etc/xinetd.conf'
+      $package_name       = 'xinetd'
+      $service_hasrestart = true
+      $service_hasstatus  = false
+      $service_name       = 'xinetd'
+      $service_restart    = "/usr/sbin/service ${service_name} reload"
     }
     'FreeBSD': {
-      $confdir       = '/usr/local/etc/xinetd.d'
-      $conffile      = '/usr/local/etc/xinetd.conf'
-      $package_name  = 'security/xinetd'
-      $service_name  = 'xinetd'
+      $confdir            = '/usr/local/etc/xinetd.d'
+      $conffile           = '/usr/local/etc/xinetd.conf'
+      $package_name       = 'security/xinetd'
+      $service_hasrestart = false
+      $service_hasstatus  = true
+      $service_name       = 'xinetd'
     }
     'Suse':  {
-      $confdir       = '/etc/xinetd.d'
-      $conffile      = '/etc/xinetd.conf'
-      $package_name  = 'xinetd'
-      $service_name  = 'xinetd'
+      $confdir            = '/etc/xinetd.d'
+      $conffile           = '/etc/xinetd.conf'
+      $package_name       = 'xinetd'
+      $service_hasrestart = true
+      $service_hasstatus  = false
+      $service_name       = 'xinetd'
+      $service_restart    = "/sbin/service ${service_name} reload"
     }
     'RedHat':  {
-      $confdir       = '/etc/xinetd.d'
-      $conffile      = '/etc/xinetd.conf'
-      $package_name  = 'xinetd'
-      $service_name  = 'xinetd'
+      $confdir            = '/etc/xinetd.d'
+      $conffile           = '/etc/xinetd.conf'
+      $package_name       = 'xinetd'
+      $service_hasrestart = true
+      $service_hasstatus  = true
+      $service_name       = 'xinetd'
+      $service_restart    = "/sbin/service ${service_name} reload"
     }
     'Linux': {
       case $::operatingsystem {


### PR DESCRIPTION
The xinetd service init scripts are pretty different per platform. This at least sets the groundwork for updating.
