### PR TITLE
removing typo in resource definition for Puppet 2.6.0

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -76,7 +76,7 @@ define xinetd::service (
   $no_access      = undef,
   $access_times   = undef,
   $log_type       = undef,
-  $bind           = undef,
+  $bind           = undef
 ) {
 
   include xinetd


### PR DESCRIPTION
This comma likely breaks our unit tests on Puppet 2.6.0:

https://travis-ci.org/theforeman/puppet-foreman_proxy/builds/9698535
