### PR TITLE
Change license from GPLv2 to ASLv2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,15 @@
-Xinetd Puppet Module. Copyright (C) 2010 Garrett Honeycutt
+Xinetd Puppet Module. Copyright (C) 2010-2014 Garrett Honeycutt
 
 Garrett Honeycutt can be contacted at: contact@garretthoneycutt.com.
 
-This program and entire repository is free software; you can
-redistribute it and/or modify it under the terms of the GNU
-General Public License version 2 as published by the Free Software
-Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
This patch changes the license to the Apache Software License v2.0
