### PR TITLE
Allow configuring log_on_* operator

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,8 +7,14 @@
 #   $ensure         - optional - defaults to 'present'
 #   $log_on_success - optional - may contain any combination of
 #                       'PID', 'HOST', 'USERID', 'EXIT', 'DURATION', 'TRAFFIC'
+#   $log_on_success_operator - optional - defaults to '+='.  This is whether or
+#                              not values specified will be add, set or remove
+#                              from the default.
 #   $log_on_failure - optional - may contain any combination of
 #                       'HOST', 'USERID', 'ATTEMPT'
+#   $log_on_failure_operator - optional - defaults to '+='.  This is whether or
+#                              not values specified will be add, set or remove
+#                              from the default.
 #   $service_type   - optional - type setting in xinetd
 #                       may contain any combinarion of 'RPC', 'INTERNAL',
 #                       'TCPMUX/TCPMUXPLUS', 'UNLISTED'
@@ -56,29 +62,31 @@
 define xinetd::service (
   $port,
   $server,
-  $ensure         = present,
-  $log_on_success = undef,
-  $log_on_failure = undef,
-  $service_type   = undef,
-  $service_name   = $title,
-  $cps            = undef,
-  $disable        = 'no',
-  $flags          = undef,
-  $group          = 'root',
-  $groups         = 'yes',
-  $instances      = 'UNLIMITED',
-  $per_source     = undef,
-  $protocol       = 'tcp',
-  $server_args    = undef,
-  $socket_type    = 'stream',
-  $user           = 'root',
-  $only_from      = undef,
-  $wait           = undef,
-  $xtype          = undef,
-  $no_access      = undef,
-  $access_times   = undef,
-  $log_type       = undef,
-  $bind           = undef
+  $ensure                  = present,
+  $log_on_success          = undef,
+  $log_on_success_operator = '+=',
+  $log_on_failure          = undef,
+  $log_on_failure_operator = '+=',
+  $service_type            = undef,
+  $service_name            = $title,
+  $cps                     = undef,
+  $disable                 = 'no',
+  $flags                   = undef,
+  $group                   = 'root',
+  $groups                  = 'yes',
+  $instances               = 'UNLIMITED',
+  $per_source              = undef,
+  $protocol                = 'tcp',
+  $server_args             = undef,
+  $socket_type             = 'stream',
+  $user                    = 'root',
+  $only_from               = undef,
+  $wait                    = undef,
+  $xtype                   = undef,
+  $no_access               = undef,
+  $access_times            = undef,
+  $log_type                = undef,
+  $bind                    = undef
 ) {
 
   include xinetd
@@ -109,7 +117,9 @@ define xinetd::service (
   # - $only_from
   # - $per_source
   # - $log_on_success
+  # - $log_on_success_operator
   # - $log_on_failure
+  # - $log_on_failure_operator
   # - $cps
   # - $flags
   # - $xtype

--- a/spec/defines/xinetd_service_spec.rb
+++ b/spec/defines/xinetd_service_spec.rb
@@ -43,4 +43,47 @@ describe 'xinetd::service' do
       should contain_file('/etc/xinetd.d/httpd').with_ensure('absent')
     }
   end
+
+  describe 'without log_on_<success|failure>' do
+    let :params do
+      default_params
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').without_content(/log_on_success/)
+      should contain_file('/etc/xinetd.d/httpd').without_content(/log_on_failure/)
+    }
+  end
+
+  describe 'with log_on_<success|failure> w/default operator' do
+    let :params do
+      default_params.merge({
+        :log_on_success => 'SUCCESS_TEST',
+        :log_on_failure => 'FAILURE_TEST',
+      })
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').with_content(
+        /log_on_success\s*\+=\s*SUCCESS_TEST/)
+      should contain_file('/etc/xinetd.d/httpd').with_content(
+        /log_on_failure\s*\+=\s*FAILURE_TEST/)
+    }
+  end
+
+  describe 'with log_on_<success|failure> with equal operator' do
+    let :params do
+      default_params.merge({
+        :log_on_success => 'SUCCESS_TEST',
+        :log_on_failure => 'FAILURE_TEST',
+        :log_on_success_operator => '=',
+        :log_on_failure_operator => '=',
+      })
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').with_content(
+        /log_on_success\s*\=\s*SUCCESS_TEST/)
+      should contain_file('/etc/xinetd.d/httpd').with_content(
+        /log_on_failure\s*\=\s*FAILURE_TEST/)
+    }
+  end
+
 end

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -28,10 +28,10 @@ service <%= @service_name %>
         per_source      = <%= @per_source %>
 <% end -%>
 <% if @log_on_success -%>
-        log_on_success += <%= @log_on_success %>
+        log_on_success <%= @log_on_success_operator %> <%= @log_on_success %>
 <% end -%>
 <% if @log_on_failure -%>
-        log_on_failure += <%= @log_on_failure %>
+        log_on_failure <%= @log_on_failure_operator %> <%= @log_on_failure %>
 <% end -%>
 <% if @cps -%>
         cps             = <%= @cps %>


### PR DESCRIPTION
The default operator for log_on_success and log_on_failure settings is
+=, which means that you cannot reduce the amount of logging.  This
change allows specifying arbitrary operators but does not change the
default.
