### PR TITLE
Remove xtype parameter

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -33,6 +33,7 @@
 #   $instances      - optional - defaults to "UNLIMITED"
 #   $only_from      - optional
 #   $wait           - optional - based on $protocol will default to "yes" for udp and "no" for tcp
+#   $xtype          - deprecated - use $service_type instead 
 #   $no_access      - optional
 #   $access_times   - optional
 #   $log_type       - optional
@@ -81,6 +82,7 @@ define xinetd::service (
   $user                    = 'root',
   $only_from               = undef,
   $wait                    = undef,
+  $xtype                   = undef,
   $no_access               = undef,
   $access_times            = undef,
   $log_type                = undef,
@@ -97,6 +99,10 @@ define xinetd::service (
       tcp => 'no',
       udp => 'yes'
     }
+  }
+
+  if $xtype {
+    warning ('The $xtype parameter to xinetd::service is deprecated. Use the service_type parameter instead.') 
   }
 
   # Template uses:
@@ -120,6 +126,7 @@ define xinetd::service (
   # - $log_on_failure_operator
   # - $cps
   # - $flags
+  # - $xtype (deprecated)
   # - $no_access
   # - $access_types
   # - $log_type

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -33,7 +33,6 @@
 #   $instances      - optional - defaults to "UNLIMITED"
 #   $only_from      - optional
 #   $wait           - optional - based on $protocol will default to "yes" for udp and "no" for tcp
-#   $xtype          - optional - determines the "type" of service, see xinetd.conf(5)
 #   $no_access      - optional
 #   $access_times   - optional
 #   $log_type       - optional
@@ -82,7 +81,6 @@ define xinetd::service (
   $user                    = 'root',
   $only_from               = undef,
   $wait                    = undef,
-  $xtype                   = undef,
   $no_access               = undef,
   $access_times            = undef,
   $log_type                = undef,
@@ -122,7 +120,6 @@ define xinetd::service (
   # - $log_on_failure_operator
   # - $cps
   # - $flags
-  # - $xtype
   # - $no_access
   # - $access_types
   # - $log_type

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -39,6 +39,9 @@ service <%= @service_name %>
 <% if @flags -%>
         flags           = <%= @flags %>
 <% end -%>
+<% if @xtype -%>
+        type            = <%= @xtype %>
+<% end -%>
 <% if @no_access -%>
         no_access       = <%= @no_access %>
 <% end -%>

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -39,9 +39,6 @@ service <%= @service_name %>
 <% if @flags -%>
         flags           = <%= @flags %>
 <% end -%>
-<% if @xtype -%>
-        type            = <%= @xtype %>
-<% end -%>
 <% if @no_access -%>
         no_access       = <%= @no_access %>
 <% end -%>


### PR DESCRIPTION
The xtype parameter is a duplicate of the service_type parameter.
It is also the only parameter which doesn't match up with the xinetd.conf(5) man page.