### PR TITLE
Initialize $service_status

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,6 +53,10 @@ class xinetd::params {
       fail("xinetd: module does not support osfamily ${::osfamily}")
     }
   }
+  
+  $service_status = $::operatingsystem ? {
+    default => true,
+  }
 
 }
 


### PR DESCRIPTION
Service status is used in init.pp but not defined in parms.pp which leads to an error in Geppetto