### PR TITLE
Pipe through instances variable from xinetd::service

### DIFF
--- a/templates/service.erb
+++ b/templates/service.erb
@@ -54,4 +54,7 @@ service <%= @service_name %>
 <% if @nice -%>
         nice            = <%= @nice %>
 <% end -%>
+<% if @instances -%>
+        instances       = <%= @instances %>
+<% end -%>
 }


### PR DESCRIPTION
The instances parameter is documented in the README.md file but never actually piped through to the template.