### PR TITLE
make port an optional parameter to xinetd::service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -21,7 +21,7 @@
 #   $cps            - optional
 #   $flags          - optional
 #   $per_source     - optional
-#   $port           - required - determines the service port
+#   $port           - optional - determines the service port (required if service is not listed in /etc/services)
 #   $server         - required - determines the program to execute for this service
 #   $server_args    - optional
 #   $disable        - optional - defaults to "no"
@@ -62,8 +62,8 @@
 #   } # xinetd::service
 #
 define xinetd::service (
-  $port,
   $server,
+  $port                    = undef,
   $ensure                  = present,
   $log_on_success          = undef,
   $log_on_success_operator = '+=',

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -3,7 +3,9 @@
 
 service <%= @service_name %>
 {
+<% if @port -%>
         port            = <%= @port %>
+<% end -%>
         disable         = <%= @disable %>
         socket_type     = <%= @socket_type %>
         protocol        = <%= @protocol %>


### PR DESCRIPTION
The `port` attribute in an xinetd service is not required, and does not have to be specified if the xinetd service name is listed in `/etc/services`.