### PR TITLE
Pipe through instances variable from xinetd::service

### DIFF
--- a/templates/service.erb
+++ b/templates/service.erb
@@ -57,4 +57,7 @@ service <%= @service_name %>
 <% if @env -%>
         env             = <%= @env %>
 <% end -%>
+<% if @instances -%>
+        instances       = <%= @instances %>
+<% end -%>
 }


### PR DESCRIPTION
The instances parameter is documented in the README.md file but never actually piped through to the template.