### PR TITLE
Add class parameter to set the connection rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ default they are *not* set, allowing the internal xinetd defaults to be used:
  * `no_access`      - Determines the remote hosts to which the particular service is unavailable.
  * `only_from`      - Determines the remote hosts to which the particular service is available.
  * `max_load`       - Takes a floating point value as the load at which the service will stop accepting connections.
+ * `cps`            - Takes two numbers to set a rate limit for incoming connections. The first number is the number of connections per second at which the service is disabled. The second number is the time in seconds before the service will be enabled again.
  * `instances`      - Determines the number of servers that can be simultaneously active for a service (the default is no limit).
  * `per_source`     - This specifies the maximum instances of this service per source IP address. 
  * `bind`           - Allows a service to be bound to a specific interface on the machine.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class xinetd (
   $no_access          = undef,
   $only_from          = undef,
   $max_load           = undef,
+  $cps                = undef,
   $instances          = undef,
   $per_source         = undef,
   $bind               = undef,

--- a/spec/classes/xinetd_init_spec.rb
+++ b/spec/classes/xinetd_init_spec.rb
@@ -21,6 +21,7 @@ describe 'xinetd' do
       should contain_file('/etc/xinetd.conf').without_content(/no_access *=/)
       should contain_file('/etc/xinetd.conf').without_content(/only_from *=/)
       should contain_file('/etc/xinetd.conf').without_content(/max_load *=/)
+      should contain_file('/etc/xinetd.conf').without_content(/cps *=/)
       should contain_file('/etc/xinetd.conf').without_content(/instances *=/)
       should contain_file('/etc/xinetd.conf').without_content(/per_source *=/)
       should contain_file('/etc/xinetd.conf').without_content(/bind *=/)
@@ -49,7 +50,8 @@ describe 'xinetd' do
         :no_access      => '128.138.209.10',
         :only_from      => '127.0.0.1',
         :max_load       => '2',
-        :instances      => '50', 
+        :cps            => '50 10',
+        :instances      => '50',
         :per_source     => '50',
         :bind           => '0.0.0.0',
         :mdns           => 'yes',
@@ -73,6 +75,7 @@ describe 'xinetd' do
       should contain_file('/etc/xinetd.conf').with_content(/no_access *= 128.138.209.10/)
       should contain_file('/etc/xinetd.conf').with_content(/only_from *= 127.0.0.1/)
       should contain_file('/etc/xinetd.conf').with_content(/max_load *= 2/)
+      should contain_file('/etc/xinetd.conf').with_content(/cps *= 50 10/)
       should contain_file('/etc/xinetd.conf').with_content(/instances *= 50/)
       should contain_file('/etc/xinetd.conf').with_content(/per_source *= 50/)
       should contain_file('/etc/xinetd.conf').with_content(/bind *= 0.0.0.0/)


### PR DESCRIPTION
The template already includes code to set the `cps` parameter in the main configuration file. Unfortunately this parameter is not in the class interface so it can't really be set. This patch adds the parameter to the class and also includes tests and an updated README.