### PR TITLE
Make server parameter optional when redirect is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ page.
 
 ### Parameters:
 
- * `server`       - required - determines the program to execute for this service
+ * `server`       - optional - determines the program to execute for this service (either this or `redirect` is required)
+ * `redirect`     - optional - ip or hostname and port of the target service (either this or `server` is required)
  * `port`         - optional - determines the service port (required if service is not listed in `/etc/services`)
  * `cps`          - optional
  * `flags`        - optional
@@ -72,7 +73,8 @@ page.
  * `wait`         - optional - based on $protocol will default to "yes" for udp and "no" for tcp
  * `service_type` - optional - type setting in xinetd
  * `nice`         - optional - integer between -20 and 19, inclusive.
- * `redirect`     - optional - ip or hostname and port of the target service
+
+Either the `server` or the `redirect` parameter must be set.
 
 ### Sample Usage
 
@@ -86,6 +88,17 @@ xinetd::service { 'tftp':
   cps         => '100 2',
   flags       => 'IPv4',
   per_source  => '11',
+}
+```
+
+```puppet
+xinetd::service { 'ssh-tunnel-host.example.com':
+  port         => '2222',
+  redirect     => 'host.example.com 22',
+  flags        => 'REUSE',
+  service_type => 'UNLISTED',
+  bind         => "${::ipaddress_eth1}",
+  only_from    => '10.130.50.174',
 }
 ```
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,7 +22,7 @@
 #   $flags          - optional
 #   $per_source     - optional
 #   $port           - optional - determines the service port (required if service is not listed in /etc/services)
-#   $server         - required - determines the program to execute for this service
+#   $server         - optional - determines the program to execute for this service
 #   $server_args    - optional
 #   $disable        - optional - defaults to "no"
 #   $socket_type    - optional - defaults to "stream"
@@ -45,7 +45,7 @@
 #   setups up a xinetd service by creating a file in /etc/xinetd.d/
 #
 # Requires:
-#   $server must be set
+#   $server or $redirect must be set
 #   $port must be set
 #
 # Sample Usage:
@@ -63,7 +63,7 @@
 #   } # xinetd::service
 #
 define xinetd::service (
-  $server,
+  $server                  = undef,
   $port                    = undef,
   $ensure                  = present,
   $log_on_success          = undef,
@@ -96,6 +96,10 @@ define xinetd::service (
 ) {
 
   include ::xinetd
+
+  unless ($server or $redirect) {
+    fail('xinetd::service needs either of server or redirect')
+  }
 
   if $user {
     $_user = $user

--- a/spec/defines/xinetd_service_spec.rb
+++ b/spec/defines/xinetd_service_spec.rb
@@ -129,13 +129,27 @@ describe 'xinetd::service' do
 
   describe 'with redirect' do
     let :params do
-      default_params.merge({
+      {
+        :port     => '80',
         :redirect => 'somehost.somewhere 65535',
-      })
+      }
     end
     it {
       should contain_file('/etc/xinetd.d/httpd').with_content(
         /redirect\s*\=\s*somehost.somewhere 65535/)
     }
+  end
+
+  describe 'without redirect and server' do
+    let :params do
+      {
+        :port => '80',
+      }
+    end
+    it 'should fail' do
+      expect {
+        should contain_class('xinetd')
+      }.to raise_error(Puppet::Error)
+    end
   end
 end

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -13,7 +13,9 @@ service <%= @service_name %>
         user            = <%= @_user %>
         group           = <%= @_group %>
         groups          = <%= @groups %>
+<% if @server -%>
         server          = <%= @server %>
+<% end -%>
 <% if @bind -%>
         bind            = <%= @bind %>
 <% end -%>


### PR DESCRIPTION
According to the documentation, the server parameter is optional if a redirection is configured. This patch makes the server parameter optional. It includes a check to make sure at least one of the parameters is defined. The manpage xinetd.conf(5) defines the precedence rule if both parameters are defined, so that is not an error.
