### PR TITLE
Allow service definition without explicit group

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ page.
  * `protocol`     - optional - defaults to "tcp"
  * `user`         - optional - defaults to "root"
  * `group`        - optional - defaults to "root"
+ * `use_default_group` - optional - set to "false" to prevent using the OS specific default group for the service, defaults to "true"
  * `instances`    - optional - defaults to "UNLIMITED"
  * `wait`         - optional - based on $protocol will default to "yes" for udp and "no" for tcp
  * `service_type` - optional - type setting in xinetd

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -29,6 +29,7 @@
 #   $protocol       - optional - defaults to "tcp"
 #   $user           - optional - defaults to "root"
 #   $group          - optional - defaults to "root"
+#   $use_default_group - optional - defaults to true
 #   $groups         - optional - defaults to "yes"
 #   $instances      - optional - defaults to "UNLIMITED"
 #   $only_from      - optional
@@ -76,6 +77,7 @@ define xinetd::service (
   $disable                 = 'no',
   $flags                   = undef,
   $group                   = undef,
+  $use_default_group       = true,
   $groups                  = 'yes',
   $instances               = 'UNLIMITED',
   $per_source              = undef,
@@ -97,13 +99,15 @@ define xinetd::service (
 
   include ::xinetd
 
+  validate_bool($use_default_group)
+
   if $user {
     $_user = $user
   } else {
     $_user = $xinetd::params::default_user
   }
 
-  if $group {
+  if $group or bool2num($use_default_group) == 0 {
     $_group = $group
   } else {
     $_group = $xinetd::params::default_group

--- a/spec/defines/xinetd_service_spec.rb
+++ b/spec/defines/xinetd_service_spec.rb
@@ -59,6 +59,33 @@ describe 'xinetd::service' do
     }
   end
 
+  describe 'with group' do
+    let :params do
+      default_params.merge({'group' => 'foo'})
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').with_content(/group\s*=\s*foo/)
+    }
+  end
+
+  describe 'with use_default_group true' do
+    let :params do
+      default_params.merge({'use_default_group' => true})
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').with_content(/group\s*=\s*root/)
+    }
+  end
+
+  describe 'with use_default_group false' do
+    let :params do
+      default_params.merge({'use_default_group' => false})
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').without_content(/group\s*=/)
+    }
+  end
+
   describe 'without log_on_<success|failure>' do
     let :params do
       default_params

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -11,7 +11,9 @@ service <%= @service_name %>
         protocol        = <%= @protocol %>
         wait            = <%= @_wait %>
         user            = <%= @_user %>
+<% if @_group -%>
         group           = <%= @_group %>
+<% end -%>
         groups          = <%= @groups %>
         server          = <%= @server %>
 <% if @bind -%>


### PR DESCRIPTION
The group setting may be omitted in a service configuration to use the users primary group. This config is currently not possible because setting the group parameter to `undef` will use the os specific default group instead. This patch adds an additional parameter `use_default_group` to control this behaviour. Using the default `true` keeps the old behaviour. Setting the parameter to `false` and leaving the group unset will omit the group setting from the service config file.
