### PR TITLE
Define service_hasstatus/hasrestart for Amazon Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,11 +71,13 @@ class xinetd::params {
     'Linux': {
       case $::operatingsystem {
         'Amazon': {
-          $confdir         = '/etc/xinetd.d'
-          $conffile        = '/etc/xinetd.conf'
-          $package_name    = 'xinetd'
-          $service_name    = 'xinetd'
-          $service_restart = undef
+          $confdir            = '/etc/xinetd.d'
+          $conffile           = '/etc/xinetd.conf'
+          $package_name       = 'xinetd'
+          $service_name       = 'xinetd'
+          $service_hasrestart = true
+          $service_hasstatus  = false
+          $service_restart    = undef
           $service_status     = undef
         }
         default: {


### PR DESCRIPTION
Ensures compatibility with strict variables, and copies "RedHat" values
as AL is roughly based on EL6.
