### PR TITLE
Added missing variables for Archlinux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -67,6 +67,8 @@ class xinetd::params {
       $service_hasrestart = true
       $service_hasstatus  = true
       $service_name       = 'xinetd'
+      $service_restart    = undef
+      $service_status     = undef
     }
     'Linux': {
       case $::operatingsystem {


### PR DESCRIPTION
```$service_restart``` and ```$service_status``` where missing for Archlinux