### PR TITLE
Make server parameter optional and allow service definition without explicit group

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ page.
 
 ### Parameters:
 
- * `server`       - required - determines the program to execute for this service
+ * `server`       - optional - determines the program to execute for this service (either this or `redirect` is required)
+ * `redirect`     - optional - ip or hostname and port of the target service (either this or `server` is required)
  * `port`         - optional - determines the service port (required if service is not listed in `/etc/services`)
  * `cps`          - optional
  * `flags`        - optional
@@ -73,7 +74,8 @@ page.
  * `wait`         - optional - based on $protocol will default to "yes" for udp and "no" for tcp
  * `service_type` - optional - type setting in xinetd
  * `nice`         - optional - integer between -20 and 19, inclusive.
- * `redirect`     - optional - ip or hostname and port of the target service
+
+Either the `server` or the `redirect` parameter must be set.
 
 ### Sample Usage
 
@@ -87,6 +89,17 @@ xinetd::service { 'tftp':
   cps         => '100 2',
   flags       => 'IPv4',
   per_source  => '11',
+}
+```
+
+```puppet
+xinetd::service { 'ssh-tunnel-host.example.com':
+  port         => '2222',
+  redirect     => 'host.example.com 22',
+  flags        => 'REUSE',
+  service_type => 'UNLISTED',
+  bind         => "${::ipaddress_eth1}",
+  only_from    => '10.130.50.174',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ page.
  * `protocol`     - optional - defaults to "tcp"
  * `user`         - optional - defaults to "root"
  * `group`        - optional - defaults to "root"
+ * `use_default_group` - optional - set to "false" to prevent using the OS specific default group for the service, defaults to "true"
  * `instances`    - optional - defaults to "UNLIMITED"
  * `wait`         - optional - based on $protocol will default to "yes" for udp and "no" for tcp
  * `service_type` - optional - type setting in xinetd

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -29,6 +29,7 @@
 #   $protocol       - optional - defaults to "tcp"
 #   $user           - optional - defaults to "root"
 #   $group          - optional - defaults to "root"
+#   $use_default_group - optional - defaults to true
 #   $groups         - optional - defaults to "yes"
 #   $instances      - optional - defaults to "UNLIMITED"
 #   $only_from      - optional
@@ -100,13 +101,15 @@ define xinetd::service (
 
   include ::xinetd
 
+  validate_bool($use_default_group)
+
   if $user {
     $_user = $user
   } else {
     $_user = $xinetd::params::default_user
   }
 
-  if $group {
+  if $group or bool2num($use_default_group) == 0 {
     $_group = $group
   } else {
     $_group = $xinetd::params::default_group

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,45 +4,43 @@
 # all parameters match up with xinetd.conf(5) man page
 #
 # Parameters:
-#   $ensure         - optional - defaults to 'present'
-#   $log_on_success - optional - may contain any combination of
-#                       'PID', 'HOST', 'USERID', 'EXIT', 'DURATION', 'TRAFFIC'
+#   $ensure                  - optional - defaults to 'present'
+#   $log_on_success          - optional - may contain any combination of
+#                            'PID', 'HOST', 'USERID', 'EXIT', 'DURATION', 'TRAFFIC'
 #   $log_on_success_operator - optional - defaults to '+='.  This is whether or
 #                              not values specified will be add, set or remove
 #                              from the default.
-#   $log_on_failure - optional - may contain any combination of
-#                       'HOST', 'USERID', 'ATTEMPT'
+#   $log_on_failure          - optional - may contain any combination of
+#                             'HOST', 'USERID', 'ATTEMPT'
 #   $log_on_failure_operator - optional - defaults to '+='.  This is whether or
 #                              not values specified will be add, set or remove
 #                              from the default.
-#   $service_type   - optional - type setting in xinetd
-#                       may contain any combinarion of 'RPC', 'INTERNAL',
-#                       'TCPMUX/TCPMUXPLUS', 'UNLISTED'
-#   $cps            - optional
-#   $flags          - optional
-#   $per_source     - optional
-#   $port           - optional - determines the service port (required if service is not listed in /etc/services)
-#   $server         - optional - determines the program to execute for this service
-#   $server_args    - optional
-#   $disable        - optional - defaults to "no"
-#   $socket_type    - optional - defaults to "stream"
-#   $protocol       - optional - defaults to "tcp"
-#   $user           - optional - defaults to "root"
-#   $group          - optional - defaults to "root"
-#   $use_default_group - optional - defaults to true
-#   $groups         - optional - defaults to "yes"
-#   $instances      - optional - defaults to "UNLIMITED"
-#   $only_from      - optional
-#   $wait           - optional - based on $protocol will default to "yes" for udp and "no" for tcp
-#   $xtype          - deprecated - use $service_type instead
-#   $no_access      - optional
-#   $access_times   - optional
-#   $log_type       - optional
-#   $bind           - optional
-#   $nice           - optional - integer between -20 and 19, inclusive.
-#   $env            - optional
-#   $passenv        - optional
-#   $redirect       - optional - ip or hostname and port of the target service
+#   $service_type            - optional - type setting in xinetd
+#                             may contain any combinarion of 'RPC', 'INTERNAL',
+#                             'TCPMUX/TCPMUXPLUS', 'UNLISTED'
+#   $cps                     - optional
+#   $flags                   - optional
+#   $per_source              - optional
+#   $port                    - optional - determines the service port (required if service is not listed in /etc/services)
+#   $server                  - optional - determines the program to execute for this service
+#   $server_args             - optional
+#   $disable                 - optional - defaults to "no"
+#   $socket_type             - optional - defaults to "stream"
+#   $protocol                - optional - defaults to "tcp"
+#   $user                    - optional - defaults to "root"
+#   $group                   - optional - defaults to "root"
+#   $use_default_group       - optional - defaults to true
+#   $groups                  - optional - defaults to "yes"
+#   $instances               - optional - defaults to "UNLIMITED"
+#   $only_from               - optional
+#   $wait                    - optional - based on $protocol will default to "yes" for udp and "no" for tcp
+#   $xtype                   - deprecated - use $service_type instead
+#   $no_access               - optional
+#   $access_times            - optional
+#   $log_type                - optional
+#   $bind                    - optional
+#   $nice                    - optional - integer between -20 and 19, inclusive.
+#   $redirect                - optional - ip or hostname and port of the target service
 #
 # Actions:
 #   setups up a xinetd service by creating a file in /etc/xinetd.d/
@@ -112,7 +110,7 @@ define xinetd::service (
     $_user = $xinetd::params::default_user
   }
 
-  if $group or bool2num($use_default_group) == 0 {
+  if $group or !$use_default_group {
     $_group = $group
   } else {
     $_group = $xinetd::params::default_group

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,7 +22,7 @@
 #   $flags          - optional
 #   $per_source     - optional
 #   $port           - optional - determines the service port (required if service is not listed in /etc/services)
-#   $server         - required - determines the program to execute for this service
+#   $server         - optional - determines the program to execute for this service
 #   $server_args    - optional
 #   $disable        - optional - defaults to "no"
 #   $socket_type    - optional - defaults to "stream"
@@ -48,7 +48,7 @@
 #   setups up a xinetd service by creating a file in /etc/xinetd.d/
 #
 # Requires:
-#   $server must be set
+#   $server or $redirect must be set
 #   $port must be set
 #
 # Sample Usage:
@@ -66,7 +66,7 @@
 #   } # xinetd::service
 #
 define xinetd::service (
-  $server,
+  $server                           = undef,
   $port                             = undef,
   $ensure                           = present,
   $log_on_success                   = undef,
@@ -79,6 +79,7 @@ define xinetd::service (
   $disable                          = 'no',
   $flags                            = undef,
   $group                            = undef,
+  Boolean $use_default_group        = true,
   $groups                           = 'yes',
   $instances                        = 'UNLIMITED',
   $per_source                       = undef,
@@ -101,7 +102,9 @@ define xinetd::service (
 
   include ::xinetd
 
-  validate_bool($use_default_group)
+  unless ($server or $redirect) {
+    fail('xinetd::service needs either of server or redirect')
+  }
 
   if $user {
     $_user = $user

--- a/spec/defines/xinetd_service_spec.rb
+++ b/spec/defines/xinetd_service_spec.rb
@@ -156,13 +156,27 @@ describe 'xinetd::service' do
 
   describe 'with redirect' do
     let :params do
-      default_params.merge({
+      {
+        :port     => '80',
         :redirect => 'somehost.somewhere 65535',
-      })
+      }
     end
     it {
       should contain_file('/etc/xinetd.d/httpd').with_content(
         /redirect\s*\=\s*somehost.somewhere 65535/)
     }
+  end
+
+  describe 'without redirect and server' do
+    let :params do
+      {
+        :port => '80',
+      }
+    end
+    it 'should fail' do
+      expect {
+        should contain_class('xinetd')
+      }.to raise_error(Puppet::Error)
+    end
   end
 end

--- a/spec/defines/xinetd_service_spec.rb
+++ b/spec/defines/xinetd_service_spec.rb
@@ -59,6 +59,33 @@ describe 'xinetd::service' do
     }
   end
 
+  describe 'with group' do
+    let :params do
+      default_params.merge({'group' => 'foo'})
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').with_content(/group\s*=\s*foo/)
+    }
+  end
+
+  describe 'with use_default_group true' do
+    let :params do
+      default_params.merge({'use_default_group' => true})
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').with_content(/group\s*=\s*root/)
+    }
+  end
+
+  describe 'with use_default_group false' do
+    let :params do
+      default_params.merge({'use_default_group' => false})
+    end
+    it {
+      should contain_file('/etc/xinetd.d/httpd').without_content(/group\s*=/)
+    }
+  end
+
   describe 'without log_on_<success|failure>' do
     let :params do
       default_params

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -11,7 +11,9 @@ service <%= @service_name %>
         protocol        = <%= @protocol %>
         wait            = <%= @_wait %>
         user            = <%= @_user %>
+<% if @_group -%>
         group           = <%= @_group %>
+<% end -%>
         groups          = <%= @groups %>
         server          = <%= @server %>
 <% if @bind -%>

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -15,7 +15,9 @@ service <%= @service_name %>
         group           = <%= @_group %>
 <% end -%>
         groups          = <%= @groups %>
+<% if @server -%>
         server          = <%= @server %>
+<% end -%>
 <% if @bind -%>
         bind            = <%= @bind %>
 <% end -%>


### PR DESCRIPTION
According to the documentation, the server parameter is optional if a
redirection is configured. This patch makes the server parameter
optional. It includes a check to make sure at least one of the
parameters is defined. The manpage xinetd.conf(5) defines the precedence
rule if both parameters are defined, so that is not an error.

The group setting may be omitted in a service configuration to use the users primary group. This config is currently not possible because setting the group parameter to undef will use the os specific default group instead. This patch adds an additional parameter use_default_group to control this behaviour. Using the default true keeps the old behaviour. Setting the parameter to false and leaving the group unset will omit the group setting from the service config file.

closes #77 and #78 