### PR TITLE
Fix example service

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ xinetd::service { 'tftp':
 ```
 
 ```puppet
-xinetd::service { 'ssh-tunnel-host.example.com':
+xinetd::service { 'ssh-tunnel-host_example_com':
   port         => '2222',
   redirect     => 'host.example.com 22',
   flags        => 'REUSE',


### PR DESCRIPTION
Don't use dots in the example service, "ssh-tunnel-host.example.com" config file will be ignored by xinetd.

From man(5) xinetd.conf:

       includedir       Takes a directory name in the form of "includedir /etc/xinetd.d".  Every file inside that directory, excluding files with names containing  a  dot  ('.') or ending with a tilde ('~'), will be parsed as xinetd configuration files.

Taken from (and tested on) CentOS 7.4