### PR TITLE
Remove unused stdlib dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,0 @@
-fixtures:
-  repositories:
-    stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-  symlinks:
-    xinetd: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -14,10 +14,5 @@
       "version_requirement": ">= 4.7.1 < 7.0.0"
     }
   ],
-  "dependencies": [
-    {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.6.0 < 6.0.0"
-    }
-  ]
+  "dependencies": []
 }


### PR DESCRIPTION
Instead of updating the metadata to allow the recently released stdlib
6, remove the dependency altogether as it isn't being used. (In the
past, `validate_bool()` from stdlib was used, but this was replaced
by the `Boolean` data type.)