### PR TITLE
Remove trailing spaces from yaml

### DIFF
--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -23,4 +23,3 @@ gettext:
   # translatable content, relative to the project root directory
   source_files:
       - './lib/**/*.rb'
-  


### PR DESCRIPTION
Yamllint cannot pass the syntax check

`yamllint -d relaxed  locales/config.yaml`